### PR TITLE
fix(server): source declaration

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -34,14 +34,12 @@ AddEventHandler("QBCore:Server:PlayerLoaded", function(player)
 	player.Functions.SyncMoney()
 end)
 
-RegisterNetEvent("qb-pefcl:server:UnloadPlayer", function(source)
-	local src = source
-	exports.pefcl:unloadPlayer(src)
+RegisterNetEvent("qb-pefcl:server:UnloadPlayer", function()
+	exports.pefcl:unloadPlayer(source)
 end)
 
-RegisterNetEvent("qb-pefcl:server:SyncMoney", function(source)
-	local src = source
-	local player = QBCore.Functions.GetPlayer(src)
+RegisterNetEvent("qb-pefcl:server:SyncMoney", function()
+	local player = QBCore.Functions.GetPlayer(source)
 	player.Functions.SyncMoney()
 end)
 


### PR DESCRIPTION
**Pull Request Description**

source is a global variable set whenever an event is triggered, the client events from qb-pefcl don't send source to the event so we use the global one, otherwise this would not work as it sends nil, also source was declared local double here as a parameter of a function is already local to the scope of the function, so making it local again is useless

**Pull Request Checklist**:
* [Yes] Have you followed the guidelines in our contributing document and Code of Conduct?
* [Yes] Have you checked to ensure there aren't other open for the same update/change?
* [No] Have you built and tested the `resource` in-game after the relevant change?
