### PR TITLE
fix(readMe): add Event for qb functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ of PEFCL and QBCore installed**
                      TriggerEvent('qb-log:server:CreateLog', 'playermoney', 'AddMoney', 'lightgreen', '**' .. GetPlayerName(self.PlayerData.source) .. ' (citizenid: ' .. self.PlayerData.citizenid .. ' | id: ' .. self.PlayerData.source .. ')** $' .. amount .. ' (' .. moneytype .. ') added, new ' .. moneytype .. ' balance: ' .. self.PlayerData.money[moneytype] .. ' reason: ' .. reason)
                  end
                  TriggerClientEvent('hud:client:OnMoneyChange', self.PlayerData.source, moneytype, amount, false)
+                 TriggerClientEvent('QBCore:Client:OnMoneyChange', self.PlayerData.source, moneytype, amount, "add", reason)
+                 TriggerEvent('QBCore:Server:OnMoneyChange', self.PlayerData.source, moneytype, amount, "add", reason)
              end
 
              return true
@@ -89,6 +91,8 @@ of PEFCL and QBCore installed**
                  if moneytype == 'bank' then
                      TriggerClientEvent('qb-phone:client:RemoveBankMoney', self.PlayerData.source, amount)
                  end
+                 TriggerClientEvent('QBCore:Client:OnMoneyChange', self.PlayerData.source, moneytype, amount, "remove", reason)
+                 TriggerEvent('QBCore:Server:OnMoneyChange', self.PlayerData.source, moneytype, amount, "remove", reason)
              end
 
              return true
@@ -115,6 +119,9 @@ of PEFCL and QBCore installed**
              if not self.Offline then
                  self.Functions.UpdatePlayerData()
                  TriggerEvent('qb-log:server:CreateLog', 'playermoney', 'SetMoney', 'green', '**' .. GetPlayerName(self.PlayerData.source) .. ' (citizenid: ' .. self.PlayerData.citizenid .. ' | id: ' .. self.PlayerData.source .. ')** $' .. amount .. ' (' .. moneytype .. ') set, new ' .. moneytype .. ' balance: ' .. self.PlayerData.money[moneytype])
+                 TriggerClientEvent('hud:client:OnMoneyChange', self.PlayerData.source, moneytype, math.abs(difference), difference < 0)
+                 TriggerClientEvent('QBCore:Client:OnMoneyChange', self.PlayerData.source, moneytype, amount, "set", reason)
+                 TriggerEvent('QBCore:Server:OnMoneyChange', self.PlayerData.source, moneytype, amount, "set", reason)
              end
 
              return true


### PR DESCRIPTION
Event OnMoneyChange wasn't triggered which caused issues for example, with ox_inventory where it didn't update player money

**Pull Request Description**

Event OnMoneyChange wasn't triggered which caused issues for example, with ox_inventory where it didn't update player money
**Pull Request Checklist**:
* [x] Have you followed the guidelines in our contributing document and Code of Conduct?
* [x] Have you checked to ensure there aren't other open for the same update/change?
* [x] Have you built and tested the `resource` in-game after the relevant change?
