### PR TITLE
Added support for ox_inventory per-item money system

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,4 +1,6 @@
-Config = {}
+Config = {
+    ox_inventory = false -- Enable if you're using ox_inventory
+}
 
 Config.BusinessAccounts = {
     ['police'] = { -- Job Name

--- a/server.lua
+++ b/server.lua
@@ -2,17 +2,29 @@ local QBCore = exports["qb-core"]:GetCoreObject()
 
 local function addCash(src, amount)
 	local Player = QBCore.Functions.GetPlayer(src)
-	Player.Functions.AddMoney("cash", amount)
+	if Config.ox_inventory then
+		exports.ox_inventory:addCash(src,amount)
+	else
+		Player.Functions.AddMoney("cash", amount)
+	end
 end
 
 local function removeCash(src, amount)
 	local Player = QBCore.Functions.GetPlayer(src)
-	Player.Functions.RemoveMoney("cash", amount)
+	if Config.ox_inventory then
+		exports.ox_inventory:removeCash(src,amount)
+	else
+		Player.Functions.RemoveMoney("cash", amount)
+	end
 end
 
 local function getCash(src)
 	local Player = QBCore.Functions.GetPlayer(src)
-	return Player.PlayerData.money["cash"] or 0
+	if Config.ox_inventory then
+		return exports.ox_inventory:getCash(src) or 0
+	else
+		return Player.PlayerData.money["cash"] or 0
+	end
 end
 
 local function loadPlayer(src, citizenid, name)


### PR DESCRIPTION
Added support for ox_inventory per-item money system

**Pull Request Description**

_Added support for the ox_inventory money system, alongside QB Core. When using pefcl with QB Core and ox_inventory, all transaction systems for cash in hand, still using QB Core's native cash system instead of ox_inventory's per-item cash system, this can be fixed with this pull request. Please review and let me know if you have any feedback or concerns about this feature._

**Pull Request Checklist**:
* [✔️] Have you followed the guidelines in our contributing document and Code of Conduct?
* [✔️] Have you checked to ensure there aren't other open for the same update/change?
* [✔️] Have you built and tested the `resource` in-game after the relevant change?
